### PR TITLE
ref: Kill use of auto keyword

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -74,5 +74,6 @@
         "cinttypes": "cpp",
         "string.h": "c"
     },
-    "python.pythonPath": ".venv/bin/python2.7"
+    "python.pythonPath": ".venv/bin/python2.7",
+    "editor.formatOnSave": true
 }


### PR DESCRIPTION
Due to the mix of automatic and manual memory management the use of auto
makes it really hard to find errors.  I converted this over to explicit
types now and I think this fixed two memory issues (use after free).