### PR TITLE
ignore cloned crashpad and in-source visual studio cruft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 .venv/
 .sentryclirc
 
+# Crashpad
+crashpad/build
+
 # Build files
 libsentry.*
 *.dylib
@@ -10,6 +13,7 @@ crashpad_wrapper
 .sentrypad-tmp/
 out/
 tmp/
+premake/.vs
 
 # Example files
 example


### PR DESCRIPTION
We'd like to ignore the new files generated by setting up and building sentrypad out of the box. 