### PR TITLE
Build both 32-bit & 64-bit versions of the SDK

### DIFF
--- a/premake/premake5.lua
+++ b/premake/premake5.lua
@@ -14,14 +14,14 @@ workspace "Sentrypad"
   configurations {"Release", "Debug"}
   symbols "On"
 
-  targetdir "bin/%{cfg.buildcfg}"
+  targetdir "bin/%{cfg.architecture}/%{cfg.buildcfg}"
 
   filter "configurations:Release"
     defines { "NDEBUG" }
     optimize "On"
 
   filter "system:windows"
-    platforms {"Win64"}
+    platforms {"x64", "Win32"}
     defines {"SENTRY_BUILD_SHARED"}
 
     -- Some defines are missing in Windows SDK version 8.1, that's why we need "latest" here.
@@ -36,10 +36,6 @@ workspace "Sentrypad"
       "_HAS_EXCEPTIONS=0",
       "_UNICODE",
     }
-  filter {"system:windows", "platforms:Win32"}
-    architecture "x86"
-  filter {"system:windows", "platforms:Win64"}
-    architecture "x64"
 
   filter {"system:macosx", "kind:ConsoleApp or SharedLib"}
     postbuildcommands {"dsymutil %{cfg.buildtarget.abspath}"}


### PR DESCRIPTION
Notably using the Win32 and x64 platform names to workaround this
premake problem:
https://github.com/premake/premake-core/issues/1171